### PR TITLE
Add support for 3.7.x style formatting

### DIFF
--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -11,10 +11,7 @@ class Config {
 
   Config();
 
-  Config.build({
-    this.dir,
-    this.generators,
-  });
+  Config.build({this.dir, this.generators});
 
   void patch(Map? _data) {
     if (_data == null) return;
@@ -38,4 +35,8 @@ class Config {
       };
   String toJson() => json.encode(toMap());
   static Config? fromJson(String data) => Config.fromMap(json.decode(data));
+  Map<String, dynamic> serialize() => {
+        'dir': dir,
+        'generators': generators?.map((dynamic i) => i?.serialize()).toList(),
+      };
 }

--- a/lib/models/generator.dart
+++ b/lib/models/generator.dart
@@ -16,12 +16,7 @@ class GeneratorConfig {
 
   GeneratorConfig();
 
-  GeneratorConfig.build({
-    this.dir,
-    this.type,
-    this.recursive,
-    this.outputFile,
-  });
+  GeneratorConfig.build({this.dir, this.type, this.recursive, this.outputFile});
 
   void patch(Map? _data) {
     if (_data == null) return;
@@ -46,4 +41,10 @@ class GeneratorConfig {
   String toJson() => json.encode(toMap());
   static GeneratorConfig? fromJson(String data) =>
       GeneratorConfig.fromMap(json.decode(data));
+  Map<String, dynamic> serialize() => {
+        'dir': dir,
+        'type': type,
+        'recursive': recursive,
+        'outputFile': outputFile,
+      };
 }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -103,7 +103,8 @@ String? getConstructorInput(FieldDeclaration field) {
 }
 
 String formatCode(String code) {
-  return DartFormatter().format(code);
+  return DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+      .format(code);
 }
 
 String getTag(Declaration i) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,9 +7,9 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ^5.12.0
+  analyzer: ^6.5.0
   watcher: ^1.1.0
-  dart_style: ^2.3.1
+  dart_style: ^3.0.1
   strings: ^2.0.2
   slugify: ^2.0.0
   glob: ^2.1.1

--- a/test/lib/models/address.dart
+++ b/test/lib/models/address.dart
@@ -7,9 +7,7 @@ class Address {
 
   Address();
 
-  Address.build({
-    required this.street,
-  });
+  Address.build({required this.street});
 
   void patch(Map? _data) {
     if (_data == null) return;
@@ -22,12 +20,8 @@ class Address {
     return Address()..patch(data);
   }
 
-  Map<String, dynamic> toMap() => {
-        'street': street,
-      };
+  Map<String, dynamic> toMap() => {'street': street};
   String toJson() => json.encode(toMap());
   static Address? fromJson(String data) => Address.fromMap(json.decode(data));
-  Map<String, dynamic> serialize() => {
-        'street': street,
-      };
+  Map<String, dynamic> serialize() => {'street': street};
 }

--- a/test/lib/models/store.dart
+++ b/test/lib/models/store.dart
@@ -7,9 +7,7 @@ class Store {
 
   Store();
 
-  Store.build({
-    this.street,
-  });
+  Store.build({this.street});
 
   void patch(Map? _data) {
     if (_data == null) return;
@@ -22,17 +20,11 @@ class Store {
     return Store()..patch(data);
   }
 
-  Map<String, dynamic> toMap() => {
-        'street': street,
-      };
+  Map<String, dynamic> toMap() => {'street': street};
   String toJson() => json.encode(toMap());
   static Store? fromJson(String data) => Store.fromMap(json.decode(data));
-  Map<String, dynamic> serialize() => {
-        'street': street,
-      };
-  static Store clone(Store from) => Store.build(
-        street: from.street,
-      );
+  Map<String, dynamic> serialize() => {'street': street};
+  static Store clone(Store from) => Store.build(street: from.street);
   void patchWith(Store clone) {
     street = clone.street;
   }

--- a/test/lib/samples/store_out.txt
+++ b/test/lib/samples/store_out.txt
@@ -7,9 +7,7 @@ class Store {
 
   Store();
 
-  Store.build({
-    this.street,
-  });
+  Store.build({this.street});
 
   void patch(Map? _data) {
     if (_data == null) return;
@@ -22,17 +20,11 @@ class Store {
     return Store()..patch(data);
   }
 
-  Map<String, dynamic> toMap() => {
-        'street': street,
-      };
+  Map<String, dynamic> toMap() => {'street': street};
   String toJson() => json.encode(toMap());
   static Store? fromJson(String data) => Store.fromMap(json.decode(data));
-  Map<String, dynamic> serialize() => {
-        'street': street,
-      };
-  static Store clone(Store from) => Store.build(
-        street: from.street,
-      );
+  Map<String, dynamic> serialize() => {'street': street};
+  static Store clone(Store from) => Store.build(street: from.street);
   void patchWith(Store clone) {
     street = clone.street;
   }


### PR DESCRIPTION
dart_style 3.0.0 and analyzer 6.5.0 is necessary to format in the new Dart 3.7.x way.

This PR:
- Updates those dependencies
- Formats the code
- Modifies test samples to correspond to expected formatted output

Just let me know if I should modify this somehow! :)