### PR TITLE
Fix bug where new files could not be generated

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -32,7 +32,13 @@ List<String?> listFiles(String path,
 String fileReadString(String path) => File(path).readAsStringSync();
 
 bool fileWriteString(String path, String data) {
-  if (fileReadString(path) != data) {
+  var fileString = "";
+  try {
+    fileString = fileReadString(path);
+  } catch (e) {
+    // file doesn't exist, write it
+  }
+  if (fileString != data) {
     File(path).writeAsStringSync(data);
     return true;
   } else {


### PR DESCRIPTION
If you're using dartgenerate to generate files to (potentially) not yet existing files, this broke in 2.0.3 since `fileReadString` throws if the file doesn't exist.

This change simply makes `fileWriteString` ignore that the file is missing.